### PR TITLE
Add option to match for strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,19 @@
 {
-    "name": "zing/laravel-scout-opensearch",
+    "name": "vormkracht10/laravel-scout-opensearch",
     "description": "Laravel Scout custom engine for OpenSearch",
     "keywords": ["opensearch", "laravel", "scout", "search"],
     "license": "MIT",
-    "homepage": "https://github.com/zingimmick/laravel-scout-opensearch",
+    "homepage": "https://github.com/vormkracht10/laravel-scout-opensearch",
     "support": {
-        "issues": "https://github.com/zingimmick/laravel-scout-opensearch/issues",
-        "source": "https://github.com/zingimmick/laravel-scout-opensearch"
+        "issues": "https://github.com/vormkracht10/laravel-scout-opensearch/issues",
+        "source": "https://github.com/vormkracht10/laravel-scout-opensearch"
     },
     "authors": [
+        {
+            "name": "Mathieu de Ruiter",
+            "email": "mathieu@vormkracht10.nl",
+            "homepage": "https://github.com/casmo"
+        },
         {
             "name": "zingimmick",
             "email": "zingimmick@outlook.com",
@@ -34,17 +39,16 @@
         "nunomaduro/larastan": "^1.0 || ^2.0",
         "orchestra/testbench": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "phpstan/phpstan-mockery": "^1.0",
-        "phpunit/phpunit": "^9.3.3 || ^10.0 || ^11.0",
-        "zing/coding-standard": "^6.4 || ^7.0"
+        "phpunit/phpunit": "^9.3.3 || ^10.0 || ^11.0"
     },
     "autoload": {
         "psr-4": {
-            "Zing\\LaravelScout\\OpenSearch\\": "src"
+            "Vormkracht10\\LaravelScout\\OpenSearch\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Zing\\LaravelScout\\OpenSearch\\Tests\\": "tests"
+            "Vormkracht10\\LaravelScout\\OpenSearch\\Tests\\": "tests"
         }
     },
     "scripts": {
@@ -70,7 +74,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Zing\\LaravelScout\\OpenSearch\\OpenSearchServiceProvider"
+                "Vormkracht10\\LaravelScout\\OpenSearch\\OpenSearchServiceProvider"
             ]
         }
     },

--- a/src/Engines/OpenSearchEngine.php
+++ b/src/Engines/OpenSearchEngine.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Engines;
+namespace Vormkracht10\LaravelScout\OpenSearch\Engines;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/src/OpenSearchServiceProvider.php
+++ b/src/OpenSearchServiceProvider.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch;
+namespace Vormkracht10\LaravelScout\OpenSearch;
 
 use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\EngineManager;
 use OpenSearch\Client;
 use OpenSearch\ClientBuilder;
-use Zing\LaravelScout\OpenSearch\Engines\OpenSearchEngine;
+use Vormkracht10\LaravelScout\OpenSearch\Engines\OpenSearchEngine;
 
 class OpenSearchServiceProvider extends ServiceProvider
 {

--- a/tests/Fixtures/CustomKeySearchableModel.php
+++ b/tests/Fixtures/CustomKeySearchableModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests\Fixtures;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures;
 
 class CustomKeySearchableModel extends SearchableModel
 {

--- a/tests/Fixtures/EmptySearchableModel.php
+++ b/tests/Fixtures/EmptySearchableModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests\Fixtures;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures;
 
 class EmptySearchableModel extends SearchableModel
 {

--- a/tests/Fixtures/SearchableAndSoftDeletesModel.php
+++ b/tests/Fixtures/SearchableAndSoftDeletesModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests\Fixtures;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/tests/Fixtures/SearchableModel.php
+++ b/tests/Fixtures/SearchableModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests\Fixtures;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures;
 
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Scout\Searchable;

--- a/tests/Fixtures/SearchableModelHasUuids.php
+++ b/tests/Fixtures/SearchableModelHasUuids.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests\Fixtures;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures;
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Fixtures/SoftDeletedEmptySearchableModel.php
+++ b/tests/Fixtures/SoftDeletedEmptySearchableModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests\Fixtures;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures;
 
 class SoftDeletedEmptySearchableModel extends SearchableModel
 {

--- a/tests/OpenSearchEngineTest.php
+++ b/tests/OpenSearchEngineTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests;
 
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Collection;
@@ -14,12 +14,12 @@ use Laravel\Scout\EngineManager;
 use Laravel\Scout\Jobs\RemoveFromSearch;
 use Mockery as m;
 use OpenSearch\Client;
-use Zing\LaravelScout\OpenSearch\Engines\OpenSearchEngine;
-use Zing\LaravelScout\OpenSearch\Tests\Fixtures\CustomKeySearchableModel;
-use Zing\LaravelScout\OpenSearch\Tests\Fixtures\EmptySearchableModel;
-use Zing\LaravelScout\OpenSearch\Tests\Fixtures\SearchableAndSoftDeletesModel;
-use Zing\LaravelScout\OpenSearch\Tests\Fixtures\SearchableModel;
-use Zing\LaravelScout\OpenSearch\Tests\Fixtures\SoftDeletedEmptySearchableModel;
+use Vormkracht10\LaravelScout\OpenSearch\Engines\OpenSearchEngine;
+use Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures\CustomKeySearchableModel;
+use Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures\EmptySearchableModel;
+use Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures\SearchableAndSoftDeletesModel;
+use Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures\SearchableModel;
+use Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures\SoftDeletedEmptySearchableModel;
 
 /**
  * @internal

--- a/tests/ScoutHasUuidsTest.php
+++ b/tests/ScoutHasUuidsTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests;
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Foundation\Testing\WithFaker;
 use Laravel\Scout\Builder;
 use OpenSearch\Client;
-use Zing\LaravelScout\OpenSearch\Tests\Fixtures\SearchableModelHasUuids;
+use Vormkracht10\LaravelScout\OpenSearch\Tests\Fixtures\SearchableModelHasUuids;
 
 /**
  * @internal

--- a/tests/ScoutTest.php
+++ b/tests/ScoutTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests;
 
 use Illuminate\Foundation\Testing\WithFaker;
 use Laravel\Scout\Builder;

--- a/tests/SearchableModel.php
+++ b/tests/SearchableModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zing\LaravelScout\OpenSearch\Tests;
+namespace Vormkracht10\LaravelScout\OpenSearch\Tests;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Config;
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\DB;
 use Laravel\Scout\ScoutServiceProvider;
 use OpenSearch\ClientBuilder;
 use Orchestra\Testbench\TestCase as BaseTestCase;
-use Zing\LaravelScout\OpenSearch\OpenSearchServiceProvider;
+use Vormkracht10\LaravelScout\OpenSearch\OpenSearchServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {


### PR DESCRIPTION
For those interested: This PR adds that where(), whereIn() and whereNotIn() can have strings as values.

E.g.

```php
$builder = Model::search()
   ->where('email', 'someone@example.com')
   ->whereIn('role', ['admin', 'user'])
   ->whereNotIn('uuid', ['00000-1111111-.....'])
   ->paginate();
```