### PR TITLE
Make it easy to run tests locally

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+echo "Ensuring Docker is running"
+
+if ! docker info > /dev/null 2>&1; then
+  echo "Please start docker first."
+  exit 1
+fi
+
+echo "Ensuring services are running"
+
+docker-compose up -d
+
+echo "Waiting for OpenSearch to be ready"
+
+until curl -s -u admin:pWGxl2AqRNW0wwQlzqz7 http://localhost:9200/_cluster/health | grep -q '"status":"green"'; do
+  echo "Waiting for OpenSearch to be ready..."
+  sleep 5
+done
+
+echo "Running tests"
+
+if OPENSEARCH_HOST='localhost:9200' OPENSEARCH_USERNAME='admin' OPENSEARCH_PASSWORD='pWGxl2AqRNW0wwQlzqz7' ./vendor/bin/phpunit; then
+    exit 0
+else
+    exit 1
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,5 @@ services:
           discovery.type: single-node
           plugins.security.disabled: 'true'
           OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'pWGxl2AqRNW0wwQlzqz7'
-        volumes:
-          - opensearch-data:/usr/share/opensearch/data
         ports:
           - '9200:9200'
-volumes:
-    opensearch-data:
-        driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+    opensearch:
+        image: opensearchproject/opensearch:latest
+        environment:
+          discovery.type: single-node
+          plugins.security.disabled: 'true'
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'pWGxl2AqRNW0wwQlzqz7'
+        volumes:
+          - opensearch-data:/usr/share/opensearch/data
+        ports:
+          - '9200:9200'
+volumes:
+    opensearch-data:
+        driver: local


### PR DESCRIPTION
Similar to https://github.com/laravel/scout/pull/978, I added a docker-compose file and a shell script to make it easy for someone to run the tests locally:
```bash
sh ./bin/test.sh
```